### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -12,7 +12,7 @@
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
-/* ---v0.05.46----- */
+/* ---v0.06.01----- */
 
 #define DEBUG
 #ifdef DEBUG


### PR DESCRIPTION
In this version the term (1-lambda)*HA + lambda*HB has removed from the H(lambda) as this one should be cancelled by the GFF term.