### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -1266,9 +1266,9 @@ void FixConstantPH::calculate_T_lambda()
     	Nf -= 1.0;
     	
     for (int j = 0; j < n_lambdas; j++)
-        KE_lambda += 0.5*m_lambdas[j]*v_lambdas[j]*v_lambdas[j]*mvv2e;
+        KE_lambda += m_lambdas[j]*v_lambdas[j]*v_lambdas[j]*mvv2e;
     if (flags & BUFFER)
-        KE_lambda_buff += 0.5*N_buff*m_lambda_buff*v_lambda_buff*v_lambda_buff*mvv2e;
+        KE_lambda_buff += N_buff*m_lambda_buff*v_lambda_buff*v_lambda_buff*mvv2e;
     
     T_lambda = (KE_lambda+KE_lambda_buff) / (Nf * k);
     


### PR DESCRIPTION
I am suspecious that there is a factor of 2 hidden in the mvv2e. To check that possibility I removed the factor 0.5 in the KE calculation for the calculate_T_lambda in the fix_constant_pH.cpp