### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -1,4 +1,3 @@
-
 // clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator


### PR DESCRIPTION
There was a bug in the indexes for the charge interpolation in the fix_constant_pH.cpp modify_qs functions...