### PR TITLE
Update fix_nh_constant_pH.cpp

### DIFF
--- a/fix_nh_constant_pH.cpp
+++ b/fix_nh_constant_pH.cpp
@@ -425,7 +425,7 @@ void FixNHConstantPH::constrain_lambdas()
    
    /* The while(true) loop was used on purpose so that even when the loop termination condition
       is satisfied the q_total is calculated for the last time with final values of lambdas */
-   while(comm) {
+   while(true) {
       // Just doing this on the root and then broadcasting the results
       if (comm->me != 0)
           break;


### PR DESCRIPTION
Constraining the total charge is just done on the root and then the result is broadcast to all the nodes... Also the energy barrier for the structure conversion was raised to 0.8kT.