### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -248,7 +248,7 @@ void FixConstantPH::setup(int /*vflag*/)
     b = 0.002957; //0.005238;
     r = 16.458; 
     m = 0.1507;
-    d = 7.50; //2.0; //The height of the barrier is 2*d
+    d = 3.50; //2.0; //The height of the barrier is 2*d
 
     // default values for the buffer potential with h = 0 from Donnin J Chem Theory Comput 2016 - Table S2
     w_buff = 200;


### PR DESCRIPTION
Lowered the free energy barrier for the lambdas[:][0] to 3.5 matching the value in the 0.07.27.