### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -76,10 +76,10 @@ FixConstantPH::FixConstantPH(LAMMPS *lmp, int narg, char **arg): Fix(lmp, narg, 
   if (comm->me == 0) {
       pHStructureFile1 = fopen(arg[4],"r"); // The command reads the file the type and charge of each atom before and after protonation
       if (pHStructureFile1 == nullptr)
-         error->all(FLERR,"Unable to open the file");
+         error->one(FLERR,"Unable to open the file");
       pHStructureFile2 = fopen(arg[5],"r");
       if (pHStructureFile2 == nullptr)
-         error->all(FLERR,"Unable to open the file");
+         error->one(FLERR,"Unable to open the file");
   }
   
   


### PR DESCRIPTION
Corrected a deadlock in the fix_constant_pH.cpp when the files are not available. Error->one changed to error->all in the if (comm->me == 0) block.