### PR TITLE
Update fix_adaptive_protonation.h

### DIFF
--- a/fix_adaptive_protonation.cpp
+++ b/fix_adaptive_protonation.cpp
@@ -518,6 +518,8 @@ void FixAdaptiveProtonation::read_molids_file()
 {
    /*
     *  File format
+    *  comment_1
+    *  comment_2
     *  n_molids 
     *  molid1
     *  molid2
@@ -526,6 +528,7 @@ void FixAdaptiveProtonation::read_molids_file()
     *  molidn
     */
   
+   char *token;
    if (comm->me == 0) {
 
       char line[128];
@@ -533,8 +536,12 @@ void FixAdaptiveProtonation::read_molids_file()
       line[strcspn(line,"\n")] = '\0';
       token = strtok(line,",");
       n_protonable = std::stoi(token);
-      if (n_protonable > n_molecules) error->one(FLERR,"Unknown error");
-      for (int i = 0; i < n_mid; i++) {
+      if (n_protonable > nmolecules) error->one(FLERR,"Unknown error");
+      // Skipping the first comment
+      fgets(line,sizeof(line),init_molid_file);
+      // Skipping the second comment
+      fgets(line,sizeof(line),init_molid_file);
+      for (int i = 0; i < n_protonable; i++) {
 	 fgets(line,sizeof(line),init_molid_file);
          line[strcspn(line,"\n")] = '\0';
 	 token = strtok(line,",");

--- a/fix_adaptive_protonation.cpp
+++ b/fix_adaptive_protonation.cpp
@@ -10,7 +10,7 @@
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
-/* ---------- v0.10.09----------------- */
+/* ---------- v0.10.15----------------- */
 // Please remove unnecessary includes 
 #include "fix_adaptive_protonation.h"
 

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -10,7 +10,7 @@
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
-/* ---v0.10.00----- */
+/* ---v0.10.15----- */
 
 #ifdef FIX_CLASS
 // clang-format off

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -123,7 +123,10 @@ namespace LAMMPS_NS {
       void deallocate_storage();
       // Allocating storage
       void allocate_storage();
+      // Reseting all the molids 
       void set_molecule_id();
+      // Reading the molids from a file <--> For the file structure please have a look at the implementation file.
+      void read_molids_file();
       // Mark phosphate atoms for protonation/deprotonation
       void mark_protonation_deprotonation();
       // Modifying the protonation state

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -72,6 +72,11 @@ namespace LAMMPS_NS {
       // <------ This part is similar to the part in the fix_constant_pH.cpp, so should be a separate class
       
       int flags;
+
+      /* When a huge number of lambdas is added to the system the simulation becomes unstable.
+         So, there might be a need to input the molids of the lambdas
+      */
+      FILE* init_molid_file;
       
 
 


### PR DESCRIPTION
Added a new method to read the initial values of molids from a file.  The reason behind such a change is that if in the begining of a simulation a large number of lambdas are added, the pppm method might become unstable.