### PR TITLE
Update fix_nh_constant_pH.h

### DIFF
--- a/fix_adaptive_protonation.cpp
+++ b/fix_adaptive_protonation.cpp
@@ -99,6 +99,14 @@ FixAdaptiveProtonation::FixAdaptiveProtonation(LAMMPS* lmp, int narg, char** arg
 	       error->one(FLERR,"Unable to open the file {}",arg[iarg+1]);
 	 }
 	 iarg += 2;
+      } else if (strcmp(arg[iarg],"intermediate_file") == 0) {
+         flags |= INIT_MID;
+         if (comm->me == 0) {
+            init_molid_file = fopen(arg[iarg+1],"r");
+            if (init_molid_file == nullptr)
+              error->one(FLERR,"Unable to open the intermediate file {}",arg[iarg+1]);
+         }
+         iarg += 2;      
       } else
          error->all(FLERR,"Unknown keyword");
    }
@@ -131,8 +139,6 @@ FixAdaptiveProtonation::FixAdaptiveProtonation(LAMMPS* lmp, int narg, char** arg
 
    if (flags & RESET_MID)
       set_molecule_id();
-   if (flags & INIT_MID)
-      read_molids_file();
 
    int nlocal = atom->nlocal;
    int * molecule = atom->molecule;
@@ -159,7 +165,16 @@ FixAdaptiveProtonation::FixAdaptiveProtonation(LAMMPS* lmp, int narg, char** arg
       deallocate_storage();
       allocate_storage();
    }
-
+   
+   
+   if (flags & INIT_MID)
+      read_molids_file();
+      
+   /* Only if it has not read the molids from a file the n_protonable should set to zero.
+    *  Otherwise, it had been set by the read_molids_file()
+    */ 
+   if (!(flags & INIT_MID))
+      n_protonable = 0; 
 }
 
 /* --------------------------------------------------------------------------------------- */
@@ -208,9 +223,6 @@ void FixAdaptiveProtonation::init()
 
    // request for a neighbor list
    neighbor->add_request(this, list_flags);
-   
-   // n_protonable
-   n_protonable = 0;
    
    std::fill(nchanges,nchanges+3,0);
 }
@@ -395,6 +407,28 @@ void FixAdaptiveProtonation::read_pH_structure_files()
 }
 
 /* ----------------------------------------------------------------------------------------
+   Writing molids into a file
+   ---------------------------------------------------------------------------------------- */
+   
+void FixAdaptiveProtonation::write_molids(const char* const file_name ) const
+{
+   if (file_name == nullptr) error->one(FLERR,"The wrong file name in fix adaptive protonation");
+   FILE* output_file = fopen(file_name,"w");
+   if (output_file == nullptr) error->one(FLERR,"Cannot open the file");
+   if (comm->me == 0) {
+      if (output_file == nullptr) error->one(FLERR,"Cannot open the molid files for writing");
+      fprintf(output_file,"%d\n",n_protonable);
+      fprintf(output_file,"The molids file\n");
+      fprintf(output_file,"with the intermediate information of the fix adaptive protonation command\n");   
+      for (int i = 0; i < n_protonable; i++) {
+         fprintf(output_file,"%d\n",protonable_molids[i]);
+      }
+      fclose(output_file);
+   }
+   output_file = nullptr;
+}
+
+/* ----------------------------------------------------------------------------------------
    Deallocating the storage
    ---------------------------------------------------------------------------------------- */
 
@@ -573,6 +607,7 @@ void FixAdaptiveProtonation::read_molids_file()
       line[strcspn(line,"\n")] = '\0';
       token = strtok(line,",");
       n_protonable = std::stoi(token);
+      // Checking that if there is enough space in the allocated arrays
       if (n_protonable > nmolecules) error->one(FLERR,"Unknown error");
       // Skipping the first comment
       fgets(line,sizeof(line),init_molid_file);

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -52,6 +52,9 @@ namespace LAMMPS_NS {
       {
          _nchanges = this->nchanges[0];
       }
+      
+      // Writes molids information to a file which can be used later with fix constant_pH whenever the commands keyword of the fix_constant_pH is invoked
+      void write_molids(const char* const file_name ) const;
 
    protected:
 
@@ -118,6 +121,7 @@ namespace LAMMPS_NS {
       // maximum number of atoms and number of molecules
       int nmax;
       int nmolecules;
+
 
       // Deallocating storage 
       void deallocate_storage();

--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -53,7 +53,8 @@ enum {
        ADAPTIVE=1<<1,
        ZEROCHARGE=1<<2,
        CONSTRAIN=1<<3,
-       COMMANDS=1<<4
+       COMMANDS=1<<4,
+       INTERMEDIATE=1<<5
      };
 
 enum {
@@ -72,7 +73,7 @@ FixConstantPH::FixConstantPH(LAMMPS *lmp, int narg, char **arg) :
     Fix(lmp, narg, arg),
     pHStructureFile1(nullptr), pHStructureFile2(nullptr),
     pH1qs(nullptr), pH2qs(nullptr), typePerProtMol(nullptr), protonable(nullptr),
-    HAs(nullptr), HBs(nullptr), Us(nullptr), dUs(nullptr),
+    HAs(nullptr), HBs(nullptr), Us(nullptr), dUs(nullptr), lambdas_j(nullptr),
     lambdas(nullptr), v_lambdas(nullptr), a_lambdas(nullptr),
     m_lambdas(nullptr), H_lambdas(nullptr), molids(nullptr),
     fs(nullptr), dfs(nullptr), fp(nullptr), GFF(nullptr),
@@ -222,6 +223,12 @@ FixConstantPH::FixConstantPH(LAMMPS *lmp, int narg, char **arg) :
 	    }
 	    read_commands_file();
 	    iarg += 2;
+	} else if (strcmp(arg[iarg],"intermediate_file") == 0) { 
+	    flags |= INTERMEDIATE;
+	    if (comm->me == 0) {
+	        intermediate_file_name = arg[iarg+1];
+	    }
+	    iarg += 2;
 	} else {
             error->all(FLERR, "Unknown fix constant_pH keyword: {}", arg[iarg]);
         }
@@ -229,6 +236,7 @@ FixConstantPH::FixConstantPH(LAMMPS *lmp, int narg, char **arg) :
 
     if (!(flags & ADAPTIVE) && (flags & COMMANDS))
         error->warning(FLERR,"The keyword \"commands\" has been used without the keyword \"adaptive\"");
+     
 	
     fixgpu = nullptr;
     
@@ -384,6 +392,14 @@ void FixConstantPH::initial_integrate(int /*vflag*/)
          int n_changes;
          fix_adaptive_protonation->get_n_changes(n_changes);
          if (n_changes) {
+            /* If there is a minimization command
+             * , the update->endstep is set to zero
+             * which causes the t_target to be inf.
+             * So, I have backed up the update->endstep
+             */ 
+            bigint endstep_backup = update->endstep;
+            /* Writing the molids in a file to be read by fix_adaptive_protonation afterwards */
+            fix_adaptive_protonation->write_molids(intermediate_file_name);
 	    // add those commands ------>
             if (flags & COMMANDS) {
                modify->clearstep_compute();
@@ -393,6 +409,8 @@ void FixConstantPH::initial_integrate(int /*vflag*/)
 	       }
 	    }
 	    // <------ add those commands
+	    update->endstep = endstep_backup;
+	    
             int n_protonable;
             fix_adaptive_protonation->get_n_protonable(n_protonable);
             this->n_lambdas = n_protonable;

--- a/fix_constant_pH.h
+++ b/fix_constant_pH.h
@@ -116,6 +116,7 @@ namespace LAMMPS_NS {
         // Buffer potential
         double U_buff, dU_buff;
         double HA_buff, HB_buff;
+        
 
 	// Functions needed to communicate with fix adaptive protonation command
 	char * fix_adaptive_protonation_id;
@@ -126,6 +127,10 @@ namespace LAMMPS_NS {
         int fp_flags;
         FILE* lambda_fp, *lambda_1_fp, *lambda_2_fp, *v_lambda_fp, *a_lambda_fp, *H_lambda_fp;
 
+
+        // The name of the intermediate file written by the fix_adaptive_protonation 
+        char* intermediate_file_name;
+        
         // output methods for a variable sized lambdas, v_lambdas, ... 
         void write_lambdas_header();
         void write_lambdas();


### PR DESCRIPTION
An intermediate file has been added to the fix_constant_pH.cpp and fix_nh_constant_pH.cpp to read and write the molids before/after the minimization whenever the protonable molids change.  A bug was solved that causes the t_target to go infinite. And many more bug fixes.