### PR TITLE
Update fix_adaptive_protonation.h

### DIFF
--- a/fix_adaptive_protonation.cpp
+++ b/fix_adaptive_protonation.cpp
@@ -693,7 +693,7 @@ void FixAdaptiveProtonation::modify_protonation_state()
                case SOLVENT:  // It came from the water ----> deprotonate it
                case NEITHER:  // First step (initial value of mark_prev is -1)
 	          q_init = q[i];
-                  //q[i] = pH1qs[type[i]][0];
+                  q[i] = pH1qs[type[i]][0];
 		  q_change_local += q[i] - q_init;
                   nchanges_local[0]++;
                   nchanges_local[2]++;

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -137,8 +137,6 @@ namespace LAMMPS_NS {
       void modify_protonation_state();
       // Setting the mark for the previous state
       void set_mark_prev();
-      // Setting the charge when a molecule goes into the solid since no longer fix_constant_pH can set its charge
-      void set_solid_charge();
 
    };
 

--- a/fix_adaptive_protonation.h
+++ b/fix_adaptive_protonation.h
@@ -137,6 +137,8 @@ namespace LAMMPS_NS {
       void modify_protonation_state();
       // Setting the mark for the previous state
       void set_mark_prev();
+      // Setting the charge when a molecule goes into the solid since no longer fix_constant_pH can set its charge
+      void set_solid_charge();
 
    };
 


### PR DESCRIPTION
A function was added to the fix_adaptive_protonation.cpp to set the charge of molecules moving form solvent to the solid phase. This function was required since the fix_constant_pH.cpp can no longer set the charge of those molecules.