### PR TITLE
Update fix_constant_pH.cpp

### DIFF
--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -1325,7 +1325,6 @@ void FixConstantPH::modify_qs(double** scales)
     for (int j = 0; j < n_lambdas; j++) {
         
         double scale0 = scales[j][0];
-        scale0 = 1.0;
 	int indx11 = std::floor(lambdas[j][1]*pHnStructures1-0.5);
         int indx12 = std::ceil(lambdas[j][1]*pHnStructures1-0.5);
         double scale1 = (lambdas[j][1]*pHnStructures1-0.5 - static_cast<double>(indx11))/(static_cast<double>(indx12)-static_cast<double>(indx11));

--- a/fix_constant_pH.cpp
+++ b/fix_constant_pH.cpp
@@ -11,7 +11,7 @@
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
-/* ---v0.10.27----- */
+/* ---v0.10.28----- */
 
 #define DEBUG
 #ifdef DEBUG

--- a/fix_nh_constant_pH.cpp
+++ b/fix_nh_constant_pH.cpp
@@ -513,9 +513,9 @@ void FixNHConstantPH::constrain_lambdas()
 
 
       if (std::abs(q_total) < etol || cycle++ > maxCycles) {
-         break;
          if (comm->me == 0 && cycle > maxCycles)
              error->warning(FLERR,"The charge constrain did not reach convergence after {} iterations",maxCycles);
+         break;
       }
       
       domega = -q_total \ 


### PR DESCRIPTION
A big in the modify_qs function of the fix_constant_pH.cpp ignored the lambdas and protonated every protonable species causing the failure of the total charge constraint.